### PR TITLE
change from div to buttons 🏗️🚧

### DIFF
--- a/src/components/Board/SmallBoard/SmallBoard.module.css
+++ b/src/components/Board/SmallBoard/SmallBoard.module.css
@@ -5,8 +5,8 @@
   justify-content: center;
 }
 
-.smallBoard div::before,
-.smallBoardFinished div::before {
+.smallBoard button::before,
+.smallBoardFinished button::before {
   content: '';
   padding-bottom: 100%;
   display: inline-block;

--- a/src/components/Board/Tile/Tile.module.css
+++ b/src/components/Board/Tile/Tile.module.css
@@ -4,6 +4,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  /* Reset Button style. */
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.tile:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 3px var(--vampire-bite);
 }
 
 .tile.normal {

--- a/src/components/Board/Tile/Tile.tsx
+++ b/src/components/Board/Tile/Tile.tsx
@@ -56,7 +56,7 @@ export function Tile(props: TileProps) {
   });
 
   return (
-    <div
+    <button
       className={classes}
       onClick={() => {
         if (clickable && onTileClicked) {
@@ -65,6 +65,6 @@ export function Tile(props: TileProps) {
       }}
     >
       {getValue()}
-    </div>
+    </button>
   );
 }


### PR DESCRIPTION
This addresses the biggest a11y issue with this site. (related to #179)

Advantages:
- keyboard accessible (tab + enter key)
- screenreaders now know that the buttons exist (they are in the accessibility tree)
- you know in a good way which button is selected or was last selected (this can also be helpful for normal users)

In a later iteration I will add good names for the buttons so that you can understand the page just using a screenreader. & I will also indicate on the button itself via the disabled flag if it is clickable or not.