### PR TITLE
fix bug where the analysis could not be started right after play

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ after_success:
   - codecov
 notifications:
   email: false
-  webhooks: https://www.travisbuddy.com/?insertMode=update

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ width="150" alt="tic tac toe logo" />
   
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/ultimate-ttt/ultimate-ttt/issues)
 [![Build Status](https://travis-ci.org/ultimate-ttt/ultimate-ttt.svg?branch=master)](https://travis-ci.org/ultimate-ttt/ultimate-ttt)
-[![Greenkeeper badge](https://badges.greenkeeper.io/ultimate-ttt/ultimate-ttt.svg)](https://greenkeeper.io/)
 [![codecov](https://codecov.io/gh/ultimate-ttt/ultimate-ttt/branch/master/graph/badge.svg)](https://codecov.io/gh/ultimate-ttt/ultimate-ttt)
 
 </div>
@@ -20,7 +19,7 @@ width="150" alt="tic tac toe logo" />
 ## Demo
 
 Below you see a quick demo of the game mechanics.
-You can test it out yourself [here](https://ultimatettt.netlify.com/)
+You can test it out yourself [here](https://playtictactoe.xyz/)
 
 <img src="https://user-images.githubusercontent.com/16801528/38771159-2815f1ec-401e-11e8-8edb-157b58403761.gif" alt="demo of the game" width="500">
 

--- a/src/components/Analysis/GameSummaryCard/GameSummaryCard.story.tsx
+++ b/src/components/Analysis/GameSummaryCard/GameSummaryCard.story.tsx
@@ -60,7 +60,7 @@ export const CrossWins: Story<GameSummaryCardProps> = (args) => (
 );
 CrossWins.args = {
   gameNumber: 1,
-  link: { tag: Link, to: '/test' }
+  link: { tag: Link, to: '/test' },
 };
 
 export const CircleWins: Story<GameSummaryCardProps> = (args) => (
@@ -85,7 +85,7 @@ export const CircleWins: Story<GameSummaryCardProps> = (args) => (
 );
 CircleWins.args = {
   gameNumber: 1,
-  link: { tag: Link, to: '/test' }
+  link: { tag: Link, to: '/test' },
 };
 
 export const Draw: Story<GameSummaryCardProps> = (args) => (
@@ -110,5 +110,5 @@ export const Draw: Story<GameSummaryCardProps> = (args) => (
 );
 Draw.args = {
   gameNumber: 1,
-  link: { tag: Link, to: '/test' }
+  link: { tag: Link, to: '/test' },
 };

--- a/src/components/Board/Tile/Tile.story.tsx
+++ b/src/components/Board/Tile/Tile.story.tsx
@@ -7,8 +7,8 @@ import styles from '../SmallBoard/SmallBoard.module.css';
 
 export default {
   title: 'Tile',
-  component: Tile
-} as Meta
+  component: Tile,
+} as Meta;
 
 const position = {
   tilePosition: { x: 0, y: 0 },
@@ -17,7 +17,11 @@ const position = {
 
 const Template: Story<TileProps> = (args) => (
   <div className={styles.smallBoard}>
-    <Tile {...args} onTileClicked={action('onTileClicked')} position={position} />
+    <Tile
+      {...args}
+      onTileClicked={action('onTileClicked')}
+      position={position}
+    />
   </div>
 );
 
@@ -33,26 +37,26 @@ Highlighted.args = {
   value: TileValue.Empty,
   isTileRound: false,
   clickable: false,
-  highlight: true
-}
+  highlight: true,
+};
 
 export const Circle = Template.bind({});
 Circle.args = {
   value: TileValue.Circle,
   isTileRound: false,
-  clickable: false  
+  clickable: false,
 };
 
 export const Cross = Template.bind({});
 Cross.args = {
   value: TileValue.Cross,
   isTileRound: false,
-  clickable: false
+  clickable: false,
 };
 
 export const Destroyed = Template.bind({});
 Destroyed.args = {
   value: TileValue.Destroyed,
   isTileRound: false,
-  clickable: false
+  clickable: false,
 };

--- a/src/components/Paging/Paging.story.tsx
+++ b/src/components/Paging/Paging.story.tsx
@@ -15,5 +15,5 @@ export const Standard: Story<PagingProps> = (args) => (
 );
 Standard.args = {
   pages: 10,
-  pageToStartWith: 10
+  pageToStartWith: 10,
 };

--- a/src/state/analysisGame/analysisGameActions.ts
+++ b/src/state/analysisGame/analysisGameActions.ts
@@ -7,6 +7,7 @@ export const LOAD_FINISHED_GAME_BY_DATE =
 export const LOAD_LATEST_FINISHED_GAME =
   'analysisGameReducer/load-latest-finished-game';
 export const SET_ANALYSIS_GAME = 'analysisGameReducer/set-analysis-game';
+export const RESET_ANALYSIS_GAME = 'analysisGameReducer/reset-analysis-game';
 export const MOVE_FORWARD_IN_HISTORY =
   'analysisGameReducer/move-forward-in-history';
 export const MOVE_BACKWARD_IN_HISTORY =
@@ -29,6 +30,10 @@ export const loadLatestFinishedGame = () => ({
 export const setAnalysisGame = (analysisGame: AnalysisGame) => ({
   type: SET_ANALYSIS_GAME,
   payload: analysisGame,
+});
+
+export const resetAnalysisGame = () => ({
+  type: RESET_ANALYSIS_GAME,
 });
 
 export const moveForwardInHistory = (numberOfMoves: number) => ({

--- a/src/state/analysisGame/analysisGameReducer.ts
+++ b/src/state/analysisGame/analysisGameReducer.ts
@@ -2,6 +2,7 @@ import { AnalysisGame, GenericAction, Player, Winner } from '../AppState';
 import {
   MOVE_BACKWARD_IN_HISTORY,
   MOVE_FORWARD_IN_HISTORY,
+  RESET_ANALYSIS_GAME,
   SET_ANALYSIS_GAME,
 } from './analysisGameActions';
 import produce from 'immer';
@@ -21,6 +22,10 @@ const initialState: AnalysisGame = {
 };
 
 const analysisGameReducer = (state = initialState, action: GenericAction) => {
+  if (action.type === RESET_ANALYSIS_GAME) {
+    return initialState;
+  }
+
   if (action.type === SET_ANALYSIS_GAME) {
     return action.payload;
   }
@@ -40,7 +45,7 @@ const analysisGameReducer = (state = initialState, action: GenericAction) => {
       lastMoveToApply = state.currentMove - movesToMoveBackward;
     }
 
-    const newState = produce(state, (draftState) => {
+    return produce(state, (draftState) => {
       draftState.currentMove = lastMoveToApply;
       const relevantMoves = state.moves.slice(0, lastMoveToApply);
 
@@ -49,7 +54,6 @@ const analysisGameReducer = (state = initialState, action: GenericAction) => {
       draftState.activeBoards = game.getCurrentActiveBoards();
       draftState.game.currentPlayer = game.getCurrentPlayer();
     });
-    return newState;
   } else {
     return state;
   }

--- a/src/state/analysisGame/analysisGameSaga.ts
+++ b/src/state/analysisGame/analysisGameSaga.ts
@@ -4,6 +4,7 @@ import {
   LOAD_FINISHED_GAME_BY_DATE,
   LOAD_FINISHED_GAME_BY_ID,
   LOAD_LATEST_FINISHED_GAME,
+  resetAnalysisGame,
   setAnalysisGame,
 } from './analysisGameActions';
 import {
@@ -20,18 +21,22 @@ function* loadFinishedGameById(action: GenericAction) {
 
   // TODO if no results in selector: try over network
 
-  if (analysisGame !== undefined) {
+  if (analysisGame === undefined) {
+    yield put(resetAnalysisGame());
+  } else {
     yield put(setAnalysisGame(analysisGame));
   }
 }
 
 function* loadFinishedGameByDate(action: GenericAction) {
-  const analysisGame: AnalysisGame | undefined = yield select(
+  const analysisGame: AnalysisGame = yield select(
     getAnalysisGameByDate,
     action.payload,
   );
 
-  if (analysisGame !== undefined) {
+  if (analysisGame === undefined) {
+    yield put(resetAnalysisGame());
+  } else {
     yield put(setAnalysisGame(analysisGame));
   }
 }
@@ -41,7 +46,9 @@ function* loadLatestFinishedGame(action: GenericAction) {
     getLatestAnalysisGame,
   );
 
-  if (analysisGame !== undefined) {
+  if (analysisGame === undefined) {
+    yield put(resetAnalysisGame());
+  } else {
     yield put(setAnalysisGame(analysisGame));
   }
 }

--- a/src/state/finishedGames/finishedGameReducer.ts
+++ b/src/state/finishedGames/finishedGameReducer.ts
@@ -12,21 +12,19 @@ const initialState: FinishedGameState[] = [];
 const finishedGameReducer = (state = initialState, action: GenericAction) => {
   switch (action.type) {
     case SAVE_GAME_DATA: {
-      const newState = produce(state, (draftState) => {
+      return produce(state, (draftState) => {
         draftState.push(action.payload);
       });
-      return newState;
     }
 
     case SAVE_GAME_DATA_PENDING: {
-      const newState = produce(state, (draftState) => {
+      return produce(state, (draftState) => {
         draftState[draftState.length - 1].saveState = 'pending';
       });
-      return newState;
     }
 
     case SAVE_GAME_DATA_REJECTED: {
-      const newState = produce(state, (draftState) => {
+      return produce(state, (draftState) => {
         // we don't know for sure actually if the last element is the element this corresponds to.
         // client id should be introduced later
         const lastElement = draftState[draftState.length - 1];
@@ -34,16 +32,14 @@ const finishedGameReducer = (state = initialState, action: GenericAction) => {
         lastElement.errorMessage = action.payload;
         draftState[draftState.length - 1] = lastElement;
       });
-      return newState;
     }
 
     case SAVE_GAME_DATA_FULFILLED: {
-      const newState = produce(state, (draftState) => {
+      return produce(state, (draftState) => {
         const lastElement = draftState[draftState.length - 1];
         lastElement.saveState = 'fulfilled';
         lastElement.id = action.payload;
       });
-      return newState;
     }
 
     default: {

--- a/src/state/selectors/finishedGames/FinishedGameStateSelectors.test.ts
+++ b/src/state/selectors/finishedGames/FinishedGameStateSelectors.test.ts
@@ -51,14 +51,13 @@ describe('FinishedGameStateSelectors', () => {
         mockParameters.winningPlayer,
         mockParameters.boards,
         mockParameters.moves,
-        new Date(2019, 4, 3, 1, 1, 0),
       );
 
       const expectedSelection = {
         winner: mockParameters.winningPlayer,
         gameState: mockParameters.boards,
         moves: mockParameters.moves,
-        date: new Date(2019, 4, 3, 1, 1, 0),
+        date: new Date().toISOString(),
       };
       expect(selected).toEqual(expectedSelection);
     });

--- a/src/state/selectors/finishedGames/FinishedGameStateSelectors.ts
+++ b/src/state/selectors/finishedGames/FinishedGameStateSelectors.ts
@@ -25,7 +25,7 @@ export const getFinishedGameData = createSelector(
       winner: winningPlayer,
       gameState: boards,
       moves: moves,
-      date: new Date(),
+      date: new Date().toISOString(),
     };
   },
 );

--- a/src/state/selectors/finishedGames/FinishedGameStateSelectors.ts
+++ b/src/state/selectors/finishedGames/FinishedGameStateSelectors.ts
@@ -18,16 +18,14 @@ export const getWinningPlayerAsString = createSelector(
   },
 );
 
-export const getDate = createSelector([], () => new Date());
-
 export const getFinishedGameData = createSelector(
-  [getWinningPlayerAsString, getBoards, getMoves, getDate],
-  (winningPlayer, boards, moves, date) => {
+  [getWinningPlayerAsString, getBoards, getMoves],
+  (winningPlayer, boards, moves) => {
     return {
       winner: winningPlayer,
       gameState: boards,
       moves: moves,
-      date: date,
+      date: new Date(),
     };
   },
 );

--- a/src/views/Analysis/Game/AnalysisGameRoute.tsx
+++ b/src/views/Analysis/Game/AnalysisGameRoute.tsx
@@ -58,7 +58,7 @@ export function AnalysisGameRoute(props: AnalysisGameRouteProps) {
       analysisGame={props.analysisGame}
     />
   ) : (
-    <NoGameFound tag="h1" center={true} />
+    <NoGameFound />
   );
 }
 

--- a/src/views/Analysis/NoGameFound.module.css
+++ b/src/views/Analysis/NoGameFound.module.css
@@ -1,6 +1,4 @@
-.noGameFoundLayout {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
+.noGameFound {
+  padding: 1em;
+  color: var(--mdc-theme-primary);
 }

--- a/src/views/Analysis/NoGameFound.tsx
+++ b/src/views/Analysis/NoGameFound.tsx
@@ -1,25 +1,13 @@
 import * as React from 'react';
-import { Typography, TypographyT } from '@rmwc/typography';
+import { Typography } from '@rmwc/typography';
 import styles from './NoGameFound.module.css';
-import classNames from 'classnames';
-
-interface NoGameFoundProps {
-  tag: string;
-  center?: boolean;
-  className?: string;
-  children?: string;
-  size?: TypographyT;
-}
+interface NoGameFoundProps {}
 
 export function NoGameFound(props: NoGameFoundProps) {
   return (
-    <div
-      className={classNames(props.className, {
-        [styles.noGameFoundLayout]: props.center,
-      })}
-    >
-      <Typography use={props.size ? props.size : 'headline3'} tag={props.tag}>
-        {props.children ? props.children : 'No game was found'}
+    <div className={styles.noGameFound}>
+      <Typography use="headline3" tag="h1">
+        No game was found
       </Typography>
     </div>
   );

--- a/src/views/Analysis/Overview/AnalysisOverview.module.css
+++ b/src/views/Analysis/Overview/AnalysisOverview.module.css
@@ -3,10 +3,11 @@
 
   /* For a smaller gap between the small boards -> em will be smaller then*/
   font-size: 7px;
+  
+  padding-left: 3em;
 }
 
 .header {
-  padding-left: 3em;
   margin-bottom: 3em;
   margin-top: 3em;
   color: var(--mdc-theme-primary);
@@ -36,9 +37,4 @@
   flex-wrap: wrap;
   justify-content: center;
   margin-bottom: 4em;
-}
-
-.noGameFound {
-  padding-top: 1em;
-  padding-left: 3em;
 }

--- a/src/views/Analysis/Overview/AnalysisOverview.tsx
+++ b/src/views/Analysis/Overview/AnalysisOverview.tsx
@@ -9,7 +9,6 @@ import { Link } from 'react-router-dom';
 import { GameSummaryCard } from '../../../components/Analysis/GameSummaryCard/GameSummaryCard';
 import { Paging } from '../../../components/Paging/Paging';
 import { useState } from 'react';
-import { NoGameFound } from '../NoGameFound';
 
 interface AnalysisOverviewProps {
   finishedGames: FinishedGameState[];
@@ -62,9 +61,9 @@ export function AnalysisOverview(props: AnalysisOverviewProps) {
           ))}
         </div>
       ) : (
-        <NoGameFound tag="h2" size="headline4" className={styles.noGameFound}>
+        <Typography use="headline4" tag="h2">
           No recently played games were found
-        </NoGameFound>
+        </Typography>
       )}
       {amountOfPages > 1 && (
         <Paging


### PR DESCRIPTION
I finally fixed a long standing bug: Right after playing a game you could not start the analysis of that game because a ISO string was searched against a Date object. Also the date object got cached via reselect so when you played multiple games offline, they all got the same Id!
Additionally when a game was not found and one was found before, it failed and silently and a different game was actually displayed!

Also included:
- streamlined design of the "No game found" headers.
Now both in the "Analysis Overview" and the "Analyse Last Game View" this header is shown on the left.
- updated domain in readme, removed obsolete greenkeeper badge

